### PR TITLE
TEAMENG-1218: Update CORS headers and make serverless version explicit

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ type Response struct {
 
 var (
 	headers = map[string]string{
-		"Access-Control-Allow-Origin":  "https://app.joinformal.com, https://app.datadoghq.com, https://app.datadoghq.eu",
+		"Access-Control-Allow-Origin":  "https://app.joinformal.com",
 		"Access-Control-Allow-Methods": "OPTIONS,POST",
 	}
 )

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ You can deploy this AWS Lambda function in two ways:
 1. Using the serverless framework
 To deploy using the Serverless framework, run the following commands:
 ```
+npm i -E serverless@4.21.1 -g
 make deploy
 sls deploy
 ```

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,5 @@
 service: decrypt-lambda
-frameworkVersion: '3'
+frameworkVersion: '4'
 
 provider:
   name: aws


### PR DESCRIPTION
# Changes

- Remove multiple origins from CORS allowed origin header: this [is not supported by browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed).
- Update the README to specify a particular serverless npm cli version so that we don't have breaking changes
- Update the YAML to be version 4